### PR TITLE
chore: add changeset for FTS5 special chars fix

### DIFF
--- a/.changeset/fix-fts5-special-chars.md
+++ b/.changeset/fix-fts5-special-chars.md
@@ -1,0 +1,5 @@
+---
+"ccrecall": patch
+---
+
+Fix FTS5 search failing with special characters (/, -, :, etc.) in query


### PR DESCRIPTION
Adds missing changeset for PR #26 (fix: escape FTS5 special chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)