### PR TITLE
fix: escape period in FTS5 search queries

### DIFF
--- a/.changeset/fix-fts5-period.md
+++ b/.changeset/fix-fts5-period.md
@@ -1,0 +1,5 @@
+---
+'ccrecall': patch
+---
+
+Fix FTS5 search failing with period (.) and plus (+) in query

--- a/src/db.ts
+++ b/src/db.ts
@@ -157,7 +157,7 @@ function escape_fts5_query(term: string): string {
 	const base_term = is_prefix ? term.slice(0, -1) : term;
 
 	// FTS5 special chars that cause syntax errors
-	const has_special = /[/\-:()^]/.test(base_term);
+	const has_special = /[./\-:()^+]/.test(base_term);
 
 	if (!has_special && !base_term.includes('"')) {
 		return term; // Safe as-is

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -174,6 +174,11 @@ describe('Database', () => {
 			expect(results.length).toBe(1);
 		});
 
+		test('handles period in search term', () => {
+			const results = db.search('meeting-notes.txt');
+			expect(results.length).toBe(1);
+		});
+
 		test('rebuild_fts does not throw', () => {
 			expect(() => db.rebuild_fts()).not.toThrow();
 		});


### PR DESCRIPTION
## Summary
- Adds `.` to FTS5 special character escape list
- Fixes searches like `transcript.txt`, `file.json`, etc.

## Test plan
- [x] New test: `handles period in search term`
- [x] All 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)