### PR TITLE
fix: scale table column width to terminal size

### DIFF
--- a/.changeset/fix-table-truncation.md
+++ b/.changeset/fix-table-truncation.md
@@ -1,5 +1,6 @@
 ---
-"ccrecall": patch
+'ccrecall': patch
 ---
 
-Fix table column truncation to scale with terminal width instead of hard 50-char cap
+Fix table column truncation to scale with terminal width instead of
+hard 50-char cap

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,9 +175,7 @@ export const query = defineCommand({
 						maxColWidth,
 						Math.max(
 							c.length,
-							...rows.map(
-								(r) => String(r[c] ?? '').length,
-							),
+							...rows.map((r) => String(r[c] ?? '').length),
 						),
 					),
 				);


### PR DESCRIPTION
## Summary
- Table output hard-capped all column values at 50 characters, silently truncating content
- Now scales max column width to `terminal_width / num_columns` with 50 as minimum floor
- Fixes truncated SQL in `ccrecall query "SELECT name, sql FROM sqlite_master..."`

Closes #24

## Test plan
- [x] All 57 existing tests pass
- [x] Verified query output shows wider columns on real db

🤖 Generated with [Claude Code](https://claude.com/claude-code)