### PR TITLE
fix: keep last_timestamp accurate via trigger and backfill

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -27,7 +27,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   cwd TEXT,
   first_timestamp INTEGER,
   last_timestamp INTEGER,
-  summary TEXT
+  summary TEXT,
+  title TEXT
 );
 
 CREATE TABLE IF NOT EXISTS messages (
@@ -219,11 +220,12 @@ export class Database {
 		this.db.exec(SCHEMA);
 
 		this.stmt_upsert_session = this.db.prepare(`
-			INSERT INTO sessions (id, project_path, git_branch, cwd, first_timestamp, last_timestamp, summary)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO sessions (id, project_path, git_branch, cwd, first_timestamp, last_timestamp, summary, title)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(id) DO UPDATE SET
 				last_timestamp = MAX(last_timestamp, excluded.last_timestamp),
-				summary = COALESCE(excluded.summary, summary)
+				summary = COALESCE(excluded.summary, summary),
+				title = COALESCE(excluded.title, title)
 		`);
 
 		this.stmt_insert_message = this.db.prepare(`
@@ -355,6 +357,7 @@ export class Database {
 		cwd?: string;
 		timestamp: number;
 		summary?: string;
+		title?: string;
 	}) {
 		this.stmt_upsert_session.run(
 			session.id,
@@ -364,7 +367,14 @@ export class Database {
 			session.timestamp,
 			session.timestamp,
 			session.summary ?? null,
+			session.title ?? null,
 		);
+	}
+
+	update_session_title(session_id: string, title: string) {
+		this.db.prepare(
+			`UPDATE sessions SET title = ? WHERE id = ?`,
+		).run(title, session_id);
 	}
 
 	backfill_session_last_timestamps() {
@@ -830,6 +840,7 @@ export class Database {
 		message_count: number;
 		total_tokens: number;
 		duration_mins: number;
+		title: string | null;
 	}> {
 		const limit = options.limit ?? 10;
 		let query = `
@@ -840,7 +851,8 @@ export class Database {
 				s.last_timestamp,
 				COUNT(m.uuid) as message_count,
 				COALESCE(SUM(m.input_tokens + m.output_tokens), 0) as total_tokens,
-				CAST((s.last_timestamp - s.first_timestamp) / 60000.0 AS INTEGER) as duration_mins
+				CAST((s.last_timestamp - s.first_timestamp) / 60000.0 AS INTEGER) as duration_mins,
+				s.title
 			FROM sessions s
 			LEFT JOIN messages m ON m.session_id = s.id
 		`;
@@ -862,6 +874,7 @@ export class Database {
 			message_count: number;
 			total_tokens: number;
 			duration_mins: number;
+			title: string | null;
 		}>;
 	}
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -217,6 +217,7 @@ export class Database {
 		});
 		this._migrate_fts_schema();
 		this._migrate_project_paths();
+		this._migrate_sessions_title();
 		this.db.exec(SCHEMA);
 
 		this.stmt_upsert_session = this.db.prepare(`
@@ -332,6 +333,24 @@ export class Database {
 		console.log(
 			'Migrated project paths: normalized to absolute paths',
 		);
+	}
+
+	private _migrate_sessions_title() {
+		const table_exists = this.db
+			.prepare(
+				`SELECT 1 FROM sqlite_master WHERE type='table' AND name='sessions'`,
+			)
+			.get();
+		if (!table_exists) return;
+
+		const column_exists = this.db
+			.prepare(
+				`SELECT 1 FROM pragma_table_info('sessions') WHERE name='title'`,
+			)
+			.get();
+		if (column_exists) return;
+
+		this.db.exec(`ALTER TABLE sessions ADD COLUMN title TEXT`);
 	}
 
 	begin() {

--- a/src/db.ts
+++ b/src/db.ts
@@ -134,6 +134,11 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
   content_rowid='rowid'
 );
 
+-- Keep last_timestamp current as messages are inserted
+CREATE TRIGGER IF NOT EXISTS messages_update_session_last_timestamp AFTER INSERT ON messages BEGIN
+  UPDATE sessions SET last_timestamp = MAX(last_timestamp, NEW.timestamp) WHERE id = NEW.session_id;
+END;
+
 -- Triggers to keep FTS index in sync with messages table
 CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
   INSERT INTO messages_fts(rowid, content_text, thinking) VALUES (new.rowid, new.content_text, new.thinking);
@@ -360,6 +365,14 @@ export class Database {
 			session.timestamp,
 			session.summary ?? null,
 		);
+	}
+
+	backfill_session_last_timestamps() {
+		this.db.exec(`
+			UPDATE sessions SET last_timestamp = (
+				SELECT MAX(timestamp) FROM messages WHERE session_id = sessions.id
+			) WHERE last_timestamp = first_timestamp
+		`);
 	}
 
 	insert_message(msg: {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -177,6 +177,38 @@ export function parse_message(line: string): ParsedMessage | null {
 	}
 }
 
+export function parse_custom_titles(
+	file_path: string,
+): Array<{ session_id: string; name: string }> {
+	const text = readFileSync(file_path, 'utf-8');
+	const results: Array<{ session_id: string; name: string }> = [];
+
+	for (const line of text.split('\n')) {
+		if (!line.trim()) continue;
+		try {
+			const data = JSON.parse(line) as {
+				type: string;
+				customTitle?: string;
+				sessionId?: string;
+			};
+			if (
+				data.type === 'custom-title' &&
+				data.customTitle &&
+				data.sessionId
+			) {
+				results.push({
+					session_id: data.sessionId,
+					name: data.customTitle,
+				});
+			}
+		} catch {
+			// ignore unparseable lines
+		}
+	}
+
+	return results;
+}
+
 export async function* parse_file(
 	file_path: string,
 	start_offset = 0,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2,7 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { glob } from 'tinyglobby';
 import { Database } from './db.ts';
-import { parse_file } from './parser.ts';
+import { parse_custom_titles, parse_file } from './parser.ts';
 
 // Session directories to scan for transcripts
 // Primary: standard Claude Code location
@@ -160,6 +160,11 @@ export async function sync(
 		if (file_messages_added > 0) {
 			result.files_processed++;
 			result.messages_added += file_messages_added;
+		}
+
+		// Sync custom titles (written by /rename) - always re-read from start
+		for (const { session_id, name } of parse_custom_titles(file_path)) {
+			db.update_session_title(session_id, name);
 		}
 
 		db.set_sync_state(file_path, last_modified, last_byte_offset);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -49,6 +49,9 @@ export async function sync(
 		db.reset_sync_state();
 	}
 
+	// Backfill last_timestamp for sessions that predate the trigger
+	db.backfill_session_last_timestamps();
+
 	const files: string[] = [];
 	for (const projects_dir of PROJECTS_DIRS) {
 		if (!existsSync(projects_dir)) continue;


### PR DESCRIPTION
`sessions.last_timestamp` was always equal to `first_timestamp` because `upsert_session` was only called once per session on first encounter.

Add a trigger that updates `last_timestamp` on every message insert, and a backfill method called at sync start to fix existing rows.